### PR TITLE
Change the color of member detail labels

### DIFF
--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -294,6 +294,10 @@ svg {
     color: var(--foreground);
 }
 
+.memberListLabel {
+    color: var(--foreground)
+}
+
 .roomContent {
     background-color: var(--background);
     border-color: var(--border);


### PR DESCRIPTION
メンバー詳細のラベルの色を修正する

| base | head  |
| - | - |
| ![Screen Shot 2019-06-07 at 17 01 56](https://user-images.githubusercontent.com/47919813/59089975-6b27d780-8946-11e9-85eb-d425332c8f2c.jpg) | ![Screen Shot 2019-06-07 at 17 01 24](https://user-images.githubusercontent.com/47919813/59089977-6d8a3180-8946-11e9-8545-0ea35a66a991.jpg) |