### PR TITLE
Fixed: Background color of room description edit dialog form

### DIFF
--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -710,6 +710,7 @@ svg {
     background: var(--background);
 }
 
+.roomInfo__textInputDescription,
 .roomInformationContent {
     background-color: var(--background);
 }

--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -714,6 +714,7 @@ svg {
     background-color: var(--background);
 }
 
+.roomDescEditDialog__form,
 .roomDescription__header {
     background-color: var(--background);
 }


### PR DESCRIPTION
部屋の概要欄編集フォームの背景色を修正

| base | head |
| - | - |
| <img width="725" alt="Screen Shot 2019-06-10 at 12 18 26" src="https://user-images.githubusercontent.com/47919813/59170537-1b315680-8b7a-11e9-98cc-f50bf58cd097.png"> | <img width="724" alt="Screen Shot 2019-06-10 at 12 18 11" src="https://user-images.githubusercontent.com/47919813/59170533-12d91b80-8b7a-11e9-8193-2f1d83498864.png"> |
| <img width="853" alt="Screen Shot 2019-06-10 at 12 18 38" src="https://user-images.githubusercontent.com/47919813/59170552-300dea00-8b7a-11e9-8509-8c17e32d4548.png"> | <img width="855" alt="Screen Shot 2019-06-10 at 12 17 50" src="https://user-images.githubusercontent.com/47919813/59170560-3734f800-8b7a-11e9-856a-0637052c3b3d.png"> |