### PR TITLE
Correct the color of header tab of setting dialog

### DIFF
--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -294,6 +294,14 @@ svg {
     color: var(--foreground);
 }
 
+.chatRoomSettingDialog__headerTab li {
+    background-color: var(--background);
+}
+
+.chatRoomSettingDialog__headerTab li:hover {
+    background-color: var(--background-second);
+}
+
 .memberListLabel {
     color: var(--foreground)
 }

--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -294,10 +294,12 @@ svg {
     color: var(--foreground);
 }
 
+.chatSettingDialog__headerTab li,
 .chatRoomSettingDialog__headerTab li {
     background-color: var(--background);
 }
 
+.chatSettingDialog__headerTab li:hover,
 .chatRoomSettingDialog__headerTab li:hover {
     background-color: var(--background-second);
 }


### PR DESCRIPTION
設定ダイアログのヘッダータブの色を修正する。

| base | head |
| - | - |
| <img width="853" alt="Screen Shot 2019-06-12 at 10 10 55" src="https://user-images.githubusercontent.com/47919813/59316746-f7e1e500-8cfa-11e9-9b01-f42806261b46.png"> | <img width="853" alt="Screen Shot 2019-06-12 at 10 10 19" src="https://user-images.githubusercontent.com/47919813/59316747-f9aba880-8cfa-11e9-9dd6-63222a0777d6.png"> |
| <img width="702" alt="Screen Shot 2019-06-12 at 10 11 10" src="https://user-images.githubusercontent.com/47919813/59316751-fca69900-8cfa-11e9-984a-eecf445094c0.png"> | <img width="701" alt="Screen Shot 2019-06-12 at 10 10 38" src="https://user-images.githubusercontent.com/47919813/59316754-fe705c80-8cfa-11e9-8ee2-743a174af913.png">| 
