### PR TITLE
Correct the border color of the message badge avatar

### DIFF
--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -394,6 +394,7 @@ svg {
 
 .messageBadge .messageBadge__avatar {
     background-color: var(--background);
+    border-color: var(--link);
 }
 
 .messageBadge .chatTimeLineTo,


### PR DESCRIPTION
messageBadge-avatar の border color が、messageBadge と異なっていたので、修正する。