### PR TITLE
Remove background color of messageBadge__avatar

### DIFF
--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -393,7 +393,6 @@ svg {
 }
 
 .messageBadge .messageBadge__avatar {
-    background-color: var(--background);
     border-color: var(--link);
 }
 

--- a/theme/gruvbox.css
+++ b/theme/gruvbox.css
@@ -393,13 +393,13 @@ svg {
 }
 
 .messageBadge .messageBadge__avatar {
-    border-color: var(--link);
+    border-color: var(--neutral_aqua);
 }
 
 .messageBadge .chatTimeLineTo,
 .messageBadge .chatTimeLineReply,
 .messageBadge__toAllBadge {
-    background-color: var(--link);
+    background-color: var(--neutral_aqua);
 }
 
 .messageBadge .chatTimeLineTo__icon,
@@ -409,11 +409,11 @@ svg {
 }
 
 .messageBadge:hover .chatTimeLineReply {
-    background-color: var(--link-second);
+    background-color: var(--bright_aqua);
 }
 
 .messageBadge:hover .chatTimeLineReply + .messageBadge__avatar {
-    border-color: var(--link-second);
+    border-color: var(--bright_aqua);
 }
 
 .linkStatus {


### PR DESCRIPTION
messageBadge__avatar の背景色は必要なかったので削除する。

変数名について指摘をいただいたので https://github.com/k-ymmt/chatwork-gruvbox-theme/pull/12#discussion_r293189312 、ここで対応する。